### PR TITLE
Contract Solidity version bump

### DIFF
--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract Migrations {
   address public owner;

--- a/contracts/SimpleStorage.sol
+++ b/contracts/SimpleStorage.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.17;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract SimpleStorage {
   uint storedData;


### PR DESCRIPTION
Bumped the Solidity version declared in the included contracts using a range for some future-proofing as well: `pragma solidity >=0.4.24 <0.6.0;`.